### PR TITLE
set kube config in ci

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-#          aws sts get-caller-identity --profile prd-data-stg-iam-PlatformAdmin
+          aws sts get-caller-identity
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,5 +98,4 @@ jobs:
           cd deployments/helm/stg/us_east_2
           terraform init
           aws eks update-kubeconfig --region us-east-2 --name main --profile prd-data-stg-iam-PlatformAdmin --role-arn arn:aws:iam::074505835657:role/PlatformAdmin
-          terraform apply -auto-approve
-#          terraform plan -lock=false
+          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,6 +97,6 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
+          aws eks update-kubeconfig --region us-east-2 --name main --role-arn arn:aws:iam::074505835657:role/PlatformAdmin
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,4 +97,6 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          terraform plan -lock=false
+          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
+          terraform apply -auto-approve
+#          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,6 +97,6 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws eks update-kubeconfig --region us-east-2 --name main --role-arn arn:aws:iam::074505835657:role/PlatformAdmin
+          aws eks update-kubeconfig --region us-east-2 --name main --profile prd-data-stg-iam-PlatformAdmin --role-arn arn:aws:iam::074505835657:role/PlatformAdmin
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws sts get-caller-identity
+#          aws sts get-caller-identity
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,9 +5,9 @@ on:
 env:
   IMAGE_TAG: ${{ github.sha }}
   IMAGE_NAME: airbyte
-  AWS_PROFILE_ACCOUNT_DEV: prd-data-dev-PlatformAdmin
-  AWS_PROFILE_ACCOUNT_STG: prd-data-stg-PlatformAdmin
-  AWS_PROFILE_ACCOUNT_PRD: prd-data-prd-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_DEV: prd-data-dev-iam-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_STG: prd-data-stg-iam-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_PRD: prd-data-prd-iam-PlatformAdmin
 
 jobs:
   branch_name:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-#          aws sts get-caller-identity
+          aws sts get-caller-identity --profile prd-data-stg-iam-PlatformAdmin
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main --profile prd-data-stg-iam-PlatformAdmin
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,6 +97,7 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
+          aws sts get-caller-identity
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,12 +92,12 @@ jobs:
         shell: bash
         run: |
           set -e
-          export AWS_PROFILE=${AWS_PROFILE}
+          export AWS_PROFILE=${AWS_PROFILE_ACCOUNT_STG}
           export TF_VAR_change_cause=${IMAGE_TAG}
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws sts get-caller-identity --profile prd-data-stg-iam-PlatformAdmin
-          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main --profile prd-data-stg-iam-PlatformAdmin
+#          aws sts get-caller-identity --profile prd-data-stg-iam-PlatformAdmin
+          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws sts get-caller-identity
-          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
+#          aws sts get-caller-identity
+          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main --profile prd-data-stg-iam-PlatformAdmin
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,8 +97,6 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-#          aws sts get-caller-identity
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
-          
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -99,5 +99,6 @@ jobs:
           terraform init
 #          aws sts get-caller-identity
           aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
+          
           terraform apply -auto-approve
 #          terraform plan -lock=false

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: git config --global url."https://${{ secrets.GH_USERNAME }}:${{ secrets.GH_TOKEN }}@github.com/viewthespace".insteadOf "https://github.com/viewthespace"
 
-      - name: plan
+      - name: deploy-stg
         shell: bash
         run: |
           set -e
@@ -99,4 +99,5 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
+          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
           terraform apply -auto-approve

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -7,9 +7,9 @@ on:
 env:
   IMAGE_TAG: ${{ github.sha }}
   IMAGE_NAME: airbyte
-  AWS_PROFILE_ACCOUNT_DEV: prd-data-dev-PlatformAdmin
-  AWS_PROFILE_ACCOUNT_STG: prd-data-stg-PlatformAdmin
-  AWS_PROFILE_ACCOUNT_PRD: prd-data-prd-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_DEV: prd-data-dev-iam-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_STG: prd-data-stg-iam-PlatformAdmin
+  AWS_PROFILE_ACCOUNT_PRD: prd-data-prd-iam-PlatformAdmin
 
 jobs:
   branch_name:
@@ -99,5 +99,5 @@ jobs:
           export TF_VAR_image_tag=${IMAGE_TAG}
           cd deployments/helm/stg/us_east_2
           terraform init
-          aws eks update-kubeconfig --region us-east-2 --name main --alias data-stg-main
+          aws eks update-kubeconfig --region us-east-2 --name main --profile prd-data-stg-iam-PlatformAdmin --role-arn arn:aws:iam::074505835657:role/PlatformAdmin
           terraform apply -auto-approve

--- a/deployments/helm/stg/us_east_2/providers.tf
+++ b/deployments/helm/stg/us_east_2/providers.tf
@@ -22,5 +22,6 @@ data "terraform_remote_state" "customization" {
 }
 
 provider "kustomization" {
-  kubeconfig_raw = data.terraform_remote_state.customization.outputs.kubeconfig
+//  kubeconfig_raw = data.terraform_remote_state.customization.outputs.kubeconfig
+  kubeconfig_path = "~/.kube/config"
 }

--- a/deployments/helm/stg/us_east_2/providers.tf
+++ b/deployments/helm/stg/us_east_2/providers.tf
@@ -9,19 +9,6 @@ provider "aws" {
   region = "us-east-2"
 }
 
-data "terraform_remote_state" "customization" {
-  backend = "s3"
-  config = {
-    bucket         = "vts-prd-terraform-backend"
-    dynamodb_table = "vts-prd-terraform-backend"
-    key            = "vts-prd-ct-074505835657/customizations/us-east-1/terraform.tfstate"
-    region         = "us-east-1"
-    role_arn       = "arn:aws:iam::856154240248:role/PlatformAdmin"
-    session_name   = "prd_vts_ctprd_data_stg_customizations"
-  }
-}
-
 provider "kustomization" {
-//  kubeconfig_raw = data.terraform_remote_state.customization.outputs.kubeconfig
   kubeconfig_path = "~/.kube/config"
 }


### PR DESCRIPTION
## What
Making these changes since the previous `terraform apply` from the merge did not work. We suspect it was because of inability to access the kube configs. Instead we are now publishing the kube configs via the AWS CLI command on CI. 
